### PR TITLE
Find a nicer way to make sure Nexus is available before running CLI commands

### DIFF
--- a/libraries/chef_nexus.rb
+++ b/libraries/chef_nexus.rb
@@ -189,6 +189,17 @@ class Chef
         end
       end
 
+      # Checks to ensure the Nexus server is available. When
+      # it is unavailable, the Chef run is failed. Otherwise
+      # the Chef run continues.
+      # 
+      # @param  node [Chef::Node] the Chef node
+      # 
+      # @return [NilClass]
+      def ensure_nexus_available(node)
+        Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+      end
+
       # Attempts to connect to the Nexus and retries if a connection 
       # cannot be made.
       # 
@@ -228,6 +239,20 @@ class Chef
         rescue NexusCli::PermissionsException, NexusCli::CouldNotConnectToNexusException, NexusCli::UnexpectedStatusCodeException => e
           false
         end
+      end
+
+      # Returns a 'safe-for-Nexus' identifier by replacing
+      # spaces with underscores and downcasing the entire
+      # String.
+      # 
+      # @param  nexus_identifier [String] a Nexus identifier
+      # 
+      # @example
+      #   Chef::Nexus.parse_identifier("Artifacts Repository") => "artifacts_repository"
+      # 
+      # @return [String] a safe-for-Nexus version of the identifier
+      def parse_identifier(nexus_identifier)
+        nexus_identifier.gsub(" ", "_").downcase
       end
 
       def decode(value)

--- a/providers/group_repository.rb
+++ b/providers/group_repository.rb
@@ -22,10 +22,10 @@ def load_current_resource
   @current_resource = Chef::Resource::NexusGroupRepository.new(new_resource.name)
 
   run_context.include_recipe "nexus::cli"
-  Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+  Chef::Nexus.ensure_nexus_available(node)
 
-  @parsed_id         = new_resource.name.gsub(" ", "_").downcase
-  @parsed_repository = new_resource.repository.gsub(" ", "_").downcase unless new_resource.repository.nil?
+  @parsed_id         = Chef::Nexus.parse_identifier(new_resource.name)
+  @parsed_repository = Chef::Nexus.parse_identifier(new_resource.repository) unless new_resource.repository.nil?
 
   @current_resource.repository @parsed_repository
 

--- a/providers/hosted_repository.rb
+++ b/providers/hosted_repository.rb
@@ -22,9 +22,9 @@ def load_current_resource
   @current_resource = Chef::Resource::NexusHostedRepository.new(new_resource.name)
 
   run_context.include_recipe "nexus::cli"
-  Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+  Chef::Nexus.ensure_nexus_available(node)
   
-  @parsed_id = new_resource.name.gsub(" ", "_").downcase
+  @parsed_id = Chef::Nexus.parse_identifier(new_resource.name)
 
   @current_resource
 end

--- a/providers/license.rb
+++ b/providers/license.rb
@@ -22,7 +22,7 @@ def load_current_resource
   @current_resource = Chef::Resource::NexusLicense.new(new_resource.name)
 
   run_context.include_recipe "nexus::cli"
-  Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+  Chef::Nexus.ensure_nexus_available(node)
   
   @current_resource
 end

--- a/providers/logging.rb
+++ b/providers/logging.rb
@@ -22,7 +22,7 @@ def load_current_resource
   @current_resource = Chef::Resource::NexusLogging.new(new_resource.name)
 
   run_context.include_recipe "nexus::cli"
-  Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+  Chef::Nexus.ensure_nexus_available(node)
 
   @current_resource
 end

--- a/providers/proxy.rb
+++ b/providers/proxy.rb
@@ -22,7 +22,7 @@ def load_current_resource
   @current_resource = Chef::Resource::NexusProxy.new(new_resource.name)
 
   run_context.include_recipe "nexus::cli"
-  Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+  Chef::Nexus.ensure_nexus_available(node)
   
   @current_resource
 end

--- a/providers/proxy_repository.rb
+++ b/providers/proxy_repository.rb
@@ -22,9 +22,9 @@ def load_current_resource
   @current_resource = Chef::Resource::NexusProxyRepository.new(new_resource.name)
 
   run_context.include_recipe "nexus::cli"
-  Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+  Chef::Nexus.ensure_nexus_available(node)
 
-  @parsed_id = new_resource.name.gsub(" ", "_").downcase
+  @parsed_id = Chef::Nexus.parse_identifier(new_resource.name)
 
   @current_resource
 end

--- a/providers/settings.rb
+++ b/providers/settings.rb
@@ -23,7 +23,7 @@ def load_current_resource
   @current_resource.value new_resource.value
 
   run_context.include_recipe "nexus::cli"
-  Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+  Chef::Nexus.ensure_nexus_available(node)
   
   @current_resource
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -23,7 +23,7 @@ def load_current_resource
   @current_resource.old_password new_resource.old_password
   
   run_context.include_recipe "nexus::cli"
-  Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
+  Chef::Nexus.ensure_nexus_available(node)
 
   @current_resource
 end


### PR DESCRIPTION
Should remove the `retries` usage in the first resource called after starting the Nexus service.
