### PR TITLE
Allow a node configurable data bag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,3 +71,7 @@ default[:nexus][:mount][:nfs][:mount_point]                    = "/mnt/nexus"
 default[:nexus][:mount][:nfs][:device_path]                    = nil
 
 default[:nexus][:logs][:logs_to_keep]                          = 30
+
+default[:nexus][:hosted_repositories] = []
+default[:nexus][:proxy_repositories]  = []
+default[:nexus][:group_repositories]  = []

--- a/libraries/chef_nexus.rb
+++ b/libraries/chef_nexus.rb
@@ -85,12 +85,9 @@ class Chef
         if Chef::Config[:solo]
           Chef::Log.info "Chef Solo does not work well with Encrypted Data Bags."
           Chef::Log.info "Returning default values in a Hash."
-          {
-            :repositories => [
-            ]
-          }
+          []
         else
-          get_nexus_data_bag(node)[:proxy_repositories]
+          node[:nexus][:proxy_repositories]
         end
       end
 
@@ -103,15 +100,13 @@ class Chef
         if Chef::Config[:solo]
           Chef::Log.info "Chef Solo does not work well with Encrypted Data Bags."
           Chef::Log.info "Returning default values in a Hash."
-          {
-            :repositories => [
-              {
-                :name => "Artifacts"
-              }
-            ]
-          }
+          [
+            {
+              :name => "Artifacts"
+            }
+          ]
         else
-          get_nexus_data_bag(node)[:hosted_repositories]
+          node[:nexus][:hosted_repositories]
         end
       end
 
@@ -124,19 +119,17 @@ class Chef
         if Chef::Config[:solo]
           Chef::Log.info "Chef Solo does not work well with Encrypted Data Bags."
           Chef::Log.info "Returning default values in a Hash."
-          {
-            :repositories => [
-              {
-                :name => "Group",
-                :add  => [
-                  "Releases",
-                  "Artifacts"
-                ]
-              }
-            ]
-          }
+          [
+            {
+              :name => "Group",
+              :add  => [
+                "Releases",
+                "Artifacts"
+              ]
+            }
+          ]
         else
-          get_nexus_data_bag(node)[:group_repositories]
+          node[:nexus][:group_repositories]
         end
       end
 

--- a/recipes/group.rb
+++ b/recipes/group.rb
@@ -17,9 +17,9 @@
 # limitations under the License.
 #
 #
-data_bag_for_node = Chef::Nexus.get_group_repositories(node)
+group_repositories = Chef::Nexus.get_group_repositories(node)
 
-data_bag_for_node[:repositories].each do |repository|
+group_repositories.each do |repository|
   
   nexus_group_repository repository[:name]
 

--- a/recipes/hosted.rb
+++ b/recipes/hosted.rb
@@ -17,9 +17,9 @@
 # limitations under the License.
 #
 #
-data_bag_for_node = Chef::Nexus.get_hosted_repositories(node)
+hosted_repositories = Chef::Nexus.get_hosted_repositories(node)
  
-data_bag_for_node[:repositories].each do |repository|
+hosted_repositories.each do |repository|
   
   nexus_hosted_repository repository[:name]
 

--- a/recipes/proxy.rb
+++ b/recipes/proxy.rb
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-data_bag_for_node = Chef::Nexus.get_proxy_repositories(node)
+proxy_repositories = Chef::Nexus.get_proxy_repositories(node)
 
-data_bag_for_node[:repositories].each do |repository|
+proxy_repositories.each do |repository|
   
   nexus_proxy_repository repository[:name] do
     action :create


### PR DESCRIPTION
I may have more than one Nexus server in an environment. I may want different configs for those Nexus servers, especially the "repositories" section.
