### PR TITLE
use an array of strings instead of hashes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,14 +46,9 @@ default[:nexus][:app_server_proxy][:ssl][:port]                = 8443
 default[:nexus][:app_server_proxy][:ssl][:key]                 = node[:fqdn]
 
 default[:nexus][:app_server_proxy][:nginx][:server_name]       = node[:fqdn]
-default[:nexus][:app_server_proxy][:nginx][:server][:options]  = {
-  :client_max_body_size    => '200M',
-  :client_body_buffer_size => '512k',
-  :keepalive_timeout       => '0'
-}
-default[:nexus][:app_server_proxy][:nginx][:proxy][:options]   = {
-  
-}
+default[:nexus][:app_server_proxy][:nginx][:server][:options]  = ["client_max_body_size 200M", "client_body_buffer_size 512k", "keepalive_timeout 0"]
+
+default[:nexus][:app_server_proxy][:nginx][:proxy][:options]   = []
 
 default[:nexus][:cli][:ssl][:verify]                           = true
 default[:nexus][:cli][:repository]                             = "releases"

--- a/templates/default/nexus_proxy.nginx.conf.erb
+++ b/templates/default/nexus_proxy.nginx.conf.erb
@@ -11,8 +11,8 @@ server {
   error_log /var/log/nginx/repository.sonatype.org.ssl.error.log;
 
   #These come from node['nexus']['nginx']['server']['options']
-  <% @server_options.each do |option, value|%>
-  <%= option %> <%= value %>;
+  <% @server_options.each do |option|%>
+  <%= option %>;
   <% end %>
 
   ssl_session_timeout 5m;
@@ -30,8 +30,8 @@ server {
     proxy_redirect     default;
 
     #These come from node['nexus']['nginx']['proxy']['options']
-    <% @proxy_options.each do |option, value|%>
-    <%= option %> <%= value %>;
+    <% @proxy_options.each do |option|%>
+    <%= option %>;
     <% end %>
   }
 }


### PR DESCRIPTION
Sometimes, you would duplicate a key because nginx configs can have the same named parameter more than once with different values. Ex:

```
proxy_cache_valid 200 301 307 60m;
proxy_cache_valid 404 1m;
```
