### PR TITLE
remove ark dependency from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Platform:
 The following cookbooks are dependencies:
 
 * java
-* ark
 * nginx
 * artifact
 


### PR DESCRIPTION
looks like ark was removed in commit 2e1ae8d29f8fd0730390da9ce516b1978ad35a8a but the listed dependency was never removed from the README.md
