### PR TITLE
fixing issue where we don't supply the updated passwords

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "kallan@riotgames.com"
 license          "Apache 2.0"
 description      "Installs/Configures nexus"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.2.1"
+version          "2.2.0"
 
 %w{ ubuntu centos }.each do |os|
   supports os


### PR DESCRIPTION
Found that we couldn't turn off the update of admin credentials in Chef 11.6.2 because of compilation issue when updated_credentials doesn't exist in data bag
