### PR TITLE
Made data bag retreival compatible with vagrant, chef solo, and knife solo

### DIFF
--- a/libraries/chef_nexus.rb
+++ b/libraries/chef_nexus.rb
@@ -203,6 +203,8 @@ class Chef
           Mash.from_hash(Chef::EncryptedDataBagItem.load(data_bag, data_bag_item).to_hash)
         rescue Net::HTTPServerException => e
           nil
+        rescue Chef::Exceptions::ValidationFailed => e
+          nil
         end
     end
   end


### PR DESCRIPTION
I found I was not able to run this cookbook using vagrant, chef solo, and knife solo for locally stored data bags.  This change catches the exception I found was thrown when a data bag was not found in this type of vagrant environment.
