### PR TITLE
Fix file mode on SSL files so they aren't readable by other

### DIFF
--- a/recipes/app_server_proxy.rb
+++ b/recipes/app_server_proxy.rb
@@ -34,13 +34,13 @@ if node[:nexus][:app_server_proxy][:use_self_signed]
 
   cookbook_file "#{node[:nginx][:dir]}/shared/certificates/nexus-proxy.crt" do
     source "self_signed_cert.crt"
-    mode   "077"
+    mode   "600"
     action :create
   end
 
   cookbook_file "#{node[:nginx][:dir]}/shared/certificates/nexus-proxy.key" do
     source "self_signed_key.key"
-    mode   "077"
+    mode   "600"
     action :create
   end
 else
@@ -57,13 +57,13 @@ else
 
   file "#{node[:nginx][:dir]}/shared/certificates/nexus-proxy.crt" do
     content certificate
-    mode    "077"
+    mode    "600"
     action :create
   end
 
   file "#{node[:nginx][:dir]}/shared/certificates/nexus-proxy.key" do
     content key
-    mode    "077"
+    mode    "600"
     action  :create
   end
 end


### PR DESCRIPTION
SSL related files are currently being created with 077 permissions. I suspect this may have been incorrectly set by someone thinking about a umask for permissions instead of the actual permissions. 

Mode should probably be changed to 600 in https://github.com/RiotGames/nexus-cookbook/blob/master/recipes/app_server_proxy.rb
