### PR TITLE
Update java and artifact dependencies

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,6 @@ version          "3.0.0"
   supports os
 end
 
-depends "java", "~> 1.12.0"
+depends "java", "~> 1.15.4"
 depends "nginx", "~> 1.6.0"
-depends "artifact", "~> 1.6.0"
+depends "artifact", "~> 1.11.0"


### PR DESCRIPTION
Use a newer Java cookbook for better JDK 7 support. See COOK-2996 for more discussion.

Stay up to date with the artifact cookbook.
