### PR TITLE
Allow newer dependencies

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,6 @@ version          "3.1.0"
   supports os
 end
 
-depends "java", "~> 1.15.4"
-depends "nginx", "~> 1.8.0"
-depends "artifact", "~> 1.11.0"
+depends "java", ">= 1.15.4"
+depends "nginx", ">= 1.8.0"
+depends "artifact", ">= 1.11.0"


### PR DESCRIPTION
This cookbook is working great with newer version of java and nginx cookbooks (tested with 1.19.0 and 2.0.4), there is no need to block their version with a ~> relation.
