### PR TITLE
Create pids and work directories

### DIFF
--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -53,6 +53,14 @@ artifact_deploy node[:nexus][:name] do
     conf_dir   = ::File.join(nexus_home, "conf")
     bin_dir    = ::File.join(nexus_home, "bin")
 
+    [ node[:nexus][:pid_dir]}, node[:nexus][:work_dir] ].each do |dir|
+      directory dir do
+        owner     node[:nexus][:user]
+        group     node[:nexus][:user]
+        recursive true
+      end
+    end
+
     template "#{bin_dir}/#{node[:nexus][:name]}" do
       source "nexus.erb"
       owner  node[:nexus][:user]


### PR DESCRIPTION
If pids and work directories are not sub-directories of nexus_home, the recipe will fail. This commit fixes it.
