### PR TITLE
replace localhost with 127.0.0.1

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,3 @@ site :opscode
 chef_api :config
 
 metadata
-
-cookbook 'yum', '= 2.4.4'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,7 +59,7 @@ default[:nexus][:app_server_proxy][:ssl][:key]                 = node[:fqdn]
 
 default[:nexus][:app_server_proxy][:use_self_signed]  = false
 default[:nexus][:app_server_proxy][:server_name]      = node[:fqdn]
-default[:nexus][:app_server_proxy][:port]             = "http://localhost:#{node[:nexus][:port]}"
+default[:nexus][:app_server_proxy][:port]             = "http://127.0.0.1:#{node[:nexus][:port]}"
 default[:nexus][:app_server_proxy][:server][:options] = [
   "client_max_body_size 200M",
   "client_body_buffer_size 512k",


### PR DESCRIPTION
resolving localhost requires some extra work, and I have an open support ticket with Sonatype where we think that an error we are receiving is because localhost is returning an IPv6 address.
