### PR TITLE
Can specify repository policy

### DIFF
--- a/providers/hosted_repository.rb
+++ b/providers/hosted_repository.rb
@@ -31,7 +31,7 @@ end
 
 action :create do
   unless repository_exists?(@current_resource.name)
-    Chef::Nexus.nexus(node).create_repository(new_resource.name, false, nil, nil, nil, nil)
+    Chef::Nexus.nexus(node).create_repository(new_resource.name, false, nil, nil, new_resource.policy, nil)
     set_publisher if new_resource.publisher
     new_resource.updated_by_last_action(true)
   end

--- a/providers/proxy_repository.rb
+++ b/providers/proxy_repository.rb
@@ -31,7 +31,7 @@ end
 
 action :create do
   unless repository_exists?(@current_resource.name)
-    Chef::Nexus.nexus(node).create_repository(new_resource.name, true, new_resource.url, nil, nil, nil)
+    Chef::Nexus.nexus(node).create_repository(new_resource.name, true, new_resource.url, nil, new_resource.policy, nil)
     set_publisher if new_resource.publisher
     set_subscriber if new_resource.subscriber
     new_resource.updated_by_last_action(true)

--- a/resources/hosted_repository.rb
+++ b/resources/hosted_repository.rb
@@ -23,3 +23,4 @@ default_action :create
 
 attribute :name, :kind_of                 => String, :name_attribute => true
 attribute :publisher, :kind_of            => [TrueClass, FalseClass], :default => nil
+attribute :policy, :kind_of               => String, :default => nil

--- a/resources/proxy_repository.rb
+++ b/resources/proxy_repository.rb
@@ -23,6 +23,7 @@ default_action :create
 
 attribute :name, :kind_of                 => String, :name_attribute => true
 attribute :url, :kind_of                  => String, :required => true
+attribute :policy, :kind_of               => String, :default => nil
 attribute :publisher, :kind_of            => [TrueClass, FalseClass], :default => nil
 attribute :subscriber, :kind_of           => [TrueClass, FalseClass], :default => nil
 attribute :preemptive_fetch, :kind_of     => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
This commit allows user of the repository resources to specify the policy (SNAPSHOT or RELEASE(default)) of a repository.
This does not break previous API.
