### PR TITLE
ini.d should link to the approiate location

### DIFF
--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -97,7 +97,7 @@ artifact_deploy node[:nexus][:name] do
     end
 
     link "/etc/init.d/nexus" do
-      to "#{bin_dir}/nexus"
+      to "#{bin_dir}/#{node[:nexus][:name]}"
     end
   }
 end


### PR DESCRIPTION
the ini.d symlink should link to the approiate location when you change node[:nexus][:name]
