### PR TITLE
Prevent nexus from being redeployed and restarted during every chef run when version has not changed

### DIFF
--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -27,9 +27,9 @@ artifact_deploy node[:nexus][:name] do
   deploy_to         node[:nexus][:home]
   owner             node[:nexus][:user]
   group             node[:nexus][:group]
-  skip_manifest_check true
   symlinks({
-    "log" => "#{node[:nexus][:bundle_name]}/logs"
+    "log" => "#{node[:nexus][:bundle_name]}/logs",
+    "tmp" => "#{node[:nexus][:bundle_name]}/tmp"
   })
 
   before_extract Proc.new {
@@ -42,9 +42,11 @@ artifact_deploy node[:nexus][:name] do
   before_symlink Proc.new {
     nexus_home = ::File.join(release_path, node[:nexus][:bundle_name])
 
-    directory "#{nexus_home}/logs" do
-      recursive true
-      action :delete
+    [ "#{nexus_home}/logs", "#{nexus_home}/tmp" ].each do |dir|
+      directory dir do
+        recursive true
+        action :delete
+      end
     end
   }
 


### PR DESCRIPTION
Skip the manifest check for artifact_deploy to prevent an unnecessary redeploy and restart of nexus during every chef run when the nexus version has not changed.

When artifact_deploy does a manifest check, it is detecting a difference every time.  I checked the yaml generated by the artifact cookbook and this is the difference that is causing a nexus redeploy to be triggered on every chef run.

```
# diff -w /tmp/saved_manifest.yml /tmp/current_manifest.yml
6,7d5
< /nexus/home/releases/2.8.1-01/nexus-2.8.1-01/tmp/nexus-ehcache/shiro-activeSessionCache.index: !binary |-
<   MzZiZDJjNmI3MjUyNTRiOTY2ZmI4ZmVmODI4YjRmNmY5ZTQxZDI4Mw==
```

Setting skip_manifest_check to true in the artifact_deploy resource will limit redeployment of nexus to the case when the version actually changes. 
