### PR TITLE
Remove private status to methods in Nexus lib

### DIFF
--- a/libraries/chef_nexus.rb
+++ b/libraries/chef_nexus.rb
@@ -174,9 +174,6 @@ class Chef
         Base64.decode64(value)
       end
 
-      private
-
-
         # Creates a new instance of a Nexus connection using only
         # the URL to the local server. This connection is anonymous.
         #


### PR DESCRIPTION
Those methods are just getters and are useful when we want to access
advanced configuration. For instance, encrypted_data_bag_for can be
used to easily encrypt/decrypt the users list in data bags.