### PR TITLE
Allow provider configuration in LWRP

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Attribute        | Description                                                  
 name             | Name of the repository to create/delete/update                             | String                | name
 publisher             | The type of repository - either "hosted" or "proxy".                | String                |
 policy           | Either "HOSTED" or "SNAPSHOT" repository policy for artifacts       | String                |
+repo_provider   | 'rubygems-hosted', 'maven2', ...etc       | String                | nil will use 'maven2'
 
 
 ## nexus\_group\_repository
@@ -137,6 +138,7 @@ Attribute        | Description                                                  
 ---------        |-------------                                                        |-----                  |--------
 name             | Name of the repository to create/delete/add_to /remove_from                            | String                | name
 repository             | Repository to add/remove from group repo                | String                |
+repo_provider   | 'rubygems-group', 'maven2', ...etc       | String                | nil will use 'maven2'
 
 
 ## nexus\_proxy\_repository
@@ -159,6 +161,7 @@ policy           | Either "HOSTED" or "SNAPSHOT" repository policy for artifacts
 publisher             | The type of repository - either "hosted" or "proxy".                | String                |
 subscriber       | Whether this repository is a subscriber to artifacts.               | TrueClass, FalseClass |
 preemptive_fetch | Whether this (proxy) repository should preemptively fetch artifacts | TrueClass, FalseClass |
+repo_provider    | 'rubygems-proxy', 'maven2', ...etc       | String                | nil will use 'maven2'
 
 ## nexus\_settings
 

--- a/providers/group_repository.rb
+++ b/providers/group_repository.rb
@@ -34,7 +34,7 @@ end
 
 action :create do
   unless group_repository_exists?(@current_resource.name)
-    Chef::Nexus.nexus(node).create_group_repository(new_resource.name, nil, nil)
+    Chef::Nexus.nexus(node).create_group_repository(new_resource.name, nil, new_resource.repo_provider)
     new_resource.updated_by_last_action(true)
   end
 end

--- a/providers/hosted_repository.rb
+++ b/providers/hosted_repository.rb
@@ -31,7 +31,7 @@ end
 
 action :create do
   unless repository_exists?(@current_resource.name)
-    Chef::Nexus.nexus(node).create_repository(new_resource.name, false, nil, nil, new_resource.policy, nil)
+    Chef::Nexus.nexus(node).create_repository(new_resource.name, false, nil, nil, new_resource.policy, new_resource.repo_provider)
     set_publisher if new_resource.publisher
     new_resource.updated_by_last_action(true)
   end

--- a/providers/proxy_repository.rb
+++ b/providers/proxy_repository.rb
@@ -31,7 +31,7 @@ end
 
 action :create do
   unless repository_exists?(@current_resource.name)
-    Chef::Nexus.nexus(node).create_repository(new_resource.name, true, new_resource.url, nil, new_resource.policy, nil)
+    Chef::Nexus.nexus(node).create_repository(new_resource.name, true, new_resource.url, nil, new_resource.policy, new_resource.repo_provider)
     set_publisher if new_resource.publisher
     set_subscriber if new_resource.subscriber
     new_resource.updated_by_last_action(true)

--- a/resources/group_repository.rb
+++ b/resources/group_repository.rb
@@ -21,5 +21,6 @@
 actions :create, :delete, :add_to, :remove_from
 default_action :create
 
-attribute :name, :kind_of       => String, :name_attribute => true
-attribute :repository, :kind_of => String
+attribute :name, :kind_of           => String, :name_attribute => true
+attribute :repository, :kind_of     => String
+attribute :repo_provider, :kind_of  => String, :default => nil

--- a/resources/hosted_repository.rb
+++ b/resources/hosted_repository.rb
@@ -24,3 +24,4 @@ default_action :create
 attribute :name, :kind_of                 => String, :name_attribute => true
 attribute :publisher, :kind_of            => [TrueClass, FalseClass], :default => nil
 attribute :policy, :kind_of               => String, :default => nil
+attribute :repo_provider, :kind_of        => String, :default => nil

--- a/resources/proxy_repository.rb
+++ b/resources/proxy_repository.rb
@@ -27,3 +27,4 @@ attribute :policy, :kind_of               => String, :default => nil
 attribute :publisher, :kind_of            => [TrueClass, FalseClass], :default => nil
 attribute :subscriber, :kind_of           => [TrueClass, FalseClass], :default => nil
 attribute :preemptive_fetch, :kind_of     => [TrueClass, FalseClass], :default => false
+attribute :repo_provider, :kind_of        => String, :default => nil


### PR DESCRIPTION
You can now use the attribute `repo_provider` for hosted, proxy and
group repositories. This will default to `maven2` but you can use
- `rubygems-hosted`
- `rubygems-group`
- `rubygems-proxy`
- `nuget-proxy`
- ...etc

Fixes #97
