### PR TITLE
add the ability to skip manifest check

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,7 @@ default[:nexus][:group]                                        = 'nexus'
 default[:nexus][:external_version]                             = '2.11.1-01'
 default[:nexus][:url]                                          = "http://download.sonatype.com/nexus/oss/nexus-#{node[:nexus][:external_version]}-bundle.tar.gz"
 default[:nexus][:checksum]                                     = 'f3c2aee1aa4bf6232b22393c1c9c1da3dfacb9ccca7ee58c85507c85748b1e67'
+default[:nexus][:skip_manifest_check]                          = false
 
 default[:nexus][:port]                                         = '8081'
 default[:nexus][:host]                                         = '0.0.0.0'

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -21,12 +21,13 @@ include_recipe "nexus::_common_system"
 include_recipe "java"
 
 artifact_deploy node[:nexus][:name] do
-  version           node[:nexus][:version]
-  artifact_location node[:nexus][:url]
-  artifact_checksum node[:nexus][:checksum]
-  deploy_to         node[:nexus][:home]
-  owner             node[:nexus][:user]
-  group             node[:nexus][:group]
+  skip_manifest_check node[:nexus][:skip_manifest_check]
+  version             node[:nexus][:version]
+  artifact_location   node[:nexus][:url]
+  artifact_checksum   node[:nexus][:checksum]
+  deploy_to           node[:nexus][:home]
+  owner               node[:nexus][:user]
+  group               node[:nexus][:group]
   symlinks({
     "log" => "#{node[:nexus][:bundle_name]}/logs",
     "tmp" => "#{node[:nexus][:bundle_name]}/tmp"


### PR DESCRIPTION
when using a wrapper cookbook when altering templates or config files
we want the ability to disable the manifest check
so that the nexus is not restarted on every chef_run
