### PR TITLE
Fix ``nexus_cli`` requirement

### DIFF
--- a/libraries/chef_nexus.rb
+++ b/libraries/chef_nexus.rb
@@ -120,6 +120,7 @@ class Chef
       # 
       # @return [Boolean] true if a connection could be made, false otherwise
       def nexus_available?(node)
+        require 'nexus_cli'
         retries = node[:nexus][:cli][:retries]
         begin
           remote = anonymous_nexus_remote(node)


### PR DESCRIPTION
This fixes chef-run failing because of NexusCli module not found.
