### PR TITLE
Remove chef_gem deprecation warning

### DIFF
--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -19,4 +19,5 @@
 #
 chef_gem "nexus_cli" do
   version "4.1.0"
+  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end

--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -19,5 +19,5 @@
 #
 chef_gem "nexus_cli" do
   version "4.1.0"
-  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
+  compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end


### PR DESCRIPTION
This will be necessary to be compatible with chef 13
