### PR TITLE
Handle  Errno::ENETUNREACH when connecting to nexus server

### DIFF
--- a/libraries/chef_nexus.rb
+++ b/libraries/chef_nexus.rb
@@ -124,7 +124,7 @@ class Chef
         begin
           remote = anonymous_nexus_remote(node)
           return remote.status['state'] == 'STARTED'
-        rescue Errno::ECONNREFUSED, NexusCli::CouldNotConnectToNexusException, NexusCli::UnexpectedStatusCodeException => e
+        rescue Errno::ECONNREFUSED, Errno::ENETUNREACH, NexusCli::CouldNotConnectToNexusException, NexusCli::UnexpectedStatusCodeException => e
           if retries > 0
             retries -= 1
             Chef::Log.info "Could not connect to Nexus, #{retries} attempt(s) left"

--- a/libraries/chef_nexus.rb
+++ b/libraries/chef_nexus.rb
@@ -23,45 +23,45 @@ class Chef
     DEFAULT_DATABAG       = "nexus"
     SSL_FILES_DATABAG     = "nexus_ssl_files"
     WILDCARD_DATABAG_ITEM = "_wildcard"
-    
+
     class << self
 
       # Loads the nexus encrypted data bag item. Attempts to load a data bag item
       # named after the current Chef environment. If one is not found, an item named
       # "_wildcard" will be used.
-      # 
+      #
       # @param node [Chef::Node] the Chef node
-      # 
+      #
       # @return [Chef::Mash] the data bag item as a Mash with indifferent access
       def get_nexus_data_bag(node)
         encrypted_data_bag_for(node, DEFAULT_DATABAG)
       end
 
       # Loads the credentials entry from the nexus data bag item
-      # 
+      #
       # @param  node [Chef::Node] the Chef node
-      # 
+      #
       # @return [Chef::Mash] the credentials entry in the data bag item
       def get_credentials(node)
         get_nexus_data_bag(node)[:credentials]
       end
 
       # Loads the license entry from the nexus data bag item
-      # 
+      #
       # @param  node [Chef::Node] the Chef node
-      # 
+      #
       # @return [Chef::Mash] the license entry in the data bag item
       def get_license(node)
         get_nexus_data_bag(node)[:license]
       end
 
       # Loads the nexus_ssl_files encrypted data bag item for this node.
-      # 
+      #
       # @example
       #   knife data bag load nexus_ssl_files _wildcard --secret-file
-      # 
+      #
       # @param  node [Chef::Node] the Chef node
-      # 
+      #
       # @return [Chef::Mash] the loaded data bag item
       def get_ssl_files_data_bag(node)
         encrypted_data_bag_for(node, SSL_FILES_DATABAG)
@@ -70,9 +70,9 @@ class Chef
       # Creates and returns an instance of a NexusCli::RemoteFactory that
       # will be authenticated with the info inside the credentials data bag
       # item.
-      # 
+      #
       # @param  node [Chef::Node] the node
-      # 
+      #
       # @return [NexusCli::RemoteFactory] a connection to a Nexus server
       def nexus(node)
         require 'nexus_cli'
@@ -105,19 +105,19 @@ class Chef
       # Checks to ensure the Nexus server is available. When
       # it is unavailable, the Chef run is failed. Otherwise
       # the Chef run continues.
-      # 
+      #
       # @param  node [Chef::Node] the Chef node
-      # 
+      #
       # @return [NilClass]
       def ensure_nexus_available(node)
         Chef::Application.fatal!("Could not connect to Nexus. Please ensure Nexus is running.") unless Chef::Nexus.nexus_available?(node)
       end
 
-      # Attempts to connect to the Nexus and retries if a connection 
+      # Attempts to connect to the Nexus and retries if a connection
       # cannot be made.
-      # 
+      #
       # @param  node [Chef::Node] the node
-      # 
+      #
       # @return [Boolean] true if a connection could be made, false otherwise
       def nexus_available?(node)
         retries = node[:nexus][:cli][:retries]
@@ -137,11 +137,11 @@ class Chef
 
       # Checks the Nexus users credentials and returns false if they
       # have been changed.
-      # 
+      #
       # @param  username [String] the Nexus username
       # @param  password [String] the Nexus password
       # @param  node [Chef::Node] the Chef node
-      # 
+      #
       # @return [Boolean] true if a connection can be made, false otherwise
       def check_old_credentials(username, password, node)
         require 'nexus_cli'
@@ -158,12 +158,12 @@ class Chef
       # Returns a 'safe-for-Nexus' identifier by replacing
       # spaces with underscores and downcasing the entire
       # String.
-      # 
+      #
       # @param  nexus_identifier [String] a Nexus identifier
-      # 
+      #
       # @example
       #   Chef::Nexus.parse_identifier("Artifacts Repository") => "artifacts_repository"
-      # 
+      #
       # @return [String] a safe-for-Nexus version of the identifier
       def parse_identifier(nexus_identifier)
         nexus_identifier.gsub(" ", "_").downcase
@@ -200,7 +200,7 @@ class Chef
             data_bag_item = encrypted_data_bag_item(node, data_bag, node.chef_environment)
             data_bag_item ||= encrypted_data_bag_item(node, data_bag, WILDCARD_DATABAG_ITEM)
             @encrypted_data_bags[data_bag] = data_bag_item
-          end          
+          end
 
           if @encrypted_data_bags[data_bag]
             return @encrypted_data_bags[data_bag]


### PR DESCRIPTION
This PR adds Errno::ENETUNREACH to connection error handling logic in order to allow the connection to be retried.

Fixes #138 
