### PR TITLE
update nginx dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email "kallan@riotgames.com"
 license          "Apache 2.0"
 description      "Installs/Configures nexus"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.3.1"
+version          "3.3.2"
 
 %w{ ubuntu centos }.each do |os|
   supports os
 end
 
 depends "java", ">= 1.15.4"
-depends "nginx", "= 2.7.6"
+depends "chef_nginx", "~> 4.0.1"
 depends "artifact", ">= 1.11.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,5 @@ version          "3.3.1"
 end
 
 depends "java", ">= 1.15.4"
-depends "nginx", ">= 1.8.0"
+depends "nginx", "= 2.7.6"
 depends "artifact", ">= 1.11.0"

--- a/recipes/app_server_proxy.rb
+++ b/recipes/app_server_proxy.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 include_recipe "nexus::_common_system"
-include_recipe "nginx"
+include_recipe "chef_nginx"
 
 directory "#{node[:nginx][:dir]}/shared/certificates" do
   owner     "root"


### PR DESCRIPTION
because of nginx cookbook's dependency, lots of dependent cookbooks are failing including this nexus cookbook.
updating the dependency to chef_nginx will fix the issues
https://github.com/chef-cookbooks/chef_nginx